### PR TITLE
Feature 43474926: Copying multiple ROM files in a directory

### DIFF
--- a/src/cmd/cp.go
+++ b/src/cmd/cp.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 
 	"github.com/robwillup/rosy/src/config"
+	"github.com/robwillup/rosy/src/filesystem"
 	"github.com/robwillup/rosy/src/platform"
 	"github.com/robwillup/rosy/src/sshutils"
 	"github.com/spf13/cobra"
@@ -49,10 +50,10 @@ copies Game.md to $HOME/RetroPie/roms/genesis.`,
 			log.Fatalln("Path to local ROM file is required.")
 		}
 
-		fmt.Println("Copying ROM file")
+		fmt.Println("Copying ROM files")
 		fmt.Println()
 
-		err := copyROMFile(args[0])
+		err := copy(args[0])
 
 		if err != nil {
 			log.Fatalf("Failed to copy ROM file. Error: %v", err)
@@ -62,6 +63,42 @@ copies Game.md to $HOME/RetroPie/roms/genesis.`,
 
 func init() {
 	rootCmd.AddCommand(cpCmd)
+}
+
+func copy(fsPath string) error {
+	isDir, err := filesystem.CheckDir(fsPath)
+
+	if err != nil {
+		return err
+	}
+
+	if isDir {
+		files, err := filesystem.GetFiles(fsPath)
+
+		if err != nil {
+			return err
+		}
+
+		if len(files) > 0 {
+			for _, file := range files {
+				err := copyROMFile(path.Join(fsPath, file))
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
+	err = copyROMFile(fsPath)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func copyROMFile(romFile string) error {

--- a/src/filesystem/input_path.go
+++ b/src/filesystem/input_path.go
@@ -1,0 +1,34 @@
+package filesystem
+
+import (
+	"os"
+)
+
+func CheckDir(fsPath string) (bool, error) {
+	fileInfo, err := os.Stat(fsPath)
+	if err != nil {
+		return false, err
+	}
+	if fileInfo.IsDir() {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func GetFiles(dir string) ([]string, error) {
+	files := []string{}
+	items, err := os.ReadDir(dir)
+
+	if err != nil {
+		return []string{}, nil
+	}
+
+	for _, item := range items {
+		if !item.IsDir() {
+			files = append(files, item.Name())
+		}
+	}
+
+	return files, nil
+}

--- a/src/filesystem/input_path_test.go
+++ b/src/filesystem/input_path_test.go
@@ -1,0 +1,37 @@
+package filesystem
+
+import (
+	"testing"
+)
+
+func TestCheckDir(t *testing.T) {
+	expected := false
+
+	actual, err := CheckDir("input_path.go")
+	if err != nil {
+		t.Fatalf("Failed to CheckDir(). Error: %t", err)
+		return
+	}
+
+	if expected != actual {
+		t.Fatal("CheckDir() failed. Expected file, returned dir.")
+		return
+	}
+}
+
+func TestGetFiles(t *testing.T) {
+	expected := []string{"input_path.go", "input_path_test.go"}
+
+	actual, err := GetFiles(".")
+	if err != nil {
+		t.Fatalf("Failed to GetFiles(). Error: %t", err)
+		return
+	}
+
+	for i, actualFile := range actual {
+		if expected[i] != actualFile {
+			t.Fatalf("Failed to GetFiles().\nExpected: %v\nActual: %v", expected[i], actualFile)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Copying multiple ROM files in a directory

This pull request adds the option to pass a directory path to the `cp` command which will list and copy all ROM files to RetroPie.

This is not yet adding searching for ROM files recursively.

This PR resolves #5 